### PR TITLE
mikutter 3.3対応

### DIFF
--- a/image_widget_factory.rb
+++ b/image_widget_factory.rb
@@ -8,6 +8,13 @@ class ImageWidgetFactory
     @image_boxes.map { |_| _.filename }.compact
   end
 
+  # アップロードされる画像のFileを返す
+  def files
+    filenames.map do |name|
+      File.open(name, 'rb')
+    end
+  end
+
   # イメージなし画像を返す
   def noimage_file
     Plugin[:"mikutter-uwm-hommage"].get_skin("noimage.png")

--- a/media_upload.rb
+++ b/media_upload.rb
@@ -6,12 +6,26 @@ module MikuTwitter::APIShortcuts
     replyto = message[:replyto]
     receiver = message[:receiver]
     data = {:status => text }
-    data[:media_ids] = message[:media_ids].join(",") if message[:media_ids].is_a?(Array)
+    iolist = message[:mediaiolist]
     data[:in_reply_to_user_id] = User.generate(receiver)[:id].to_s if receiver
     data[:in_reply_to_status_id] = Message.generate(replyto)[:id].to_s if replyto
-    (self/'statuses/update').message(data) end
+    if iolist and !iolist.empty?
+      Deferred.when(*iolist.collect{ |io| upload_media(io) }).next{|media_list|
+        data[:media_ids] = media_list.map{|media| media['media_id'] }.join(",")
+        (self/'statuses/update').message(data)
+      }
+    else
+      (self/'statuses/update').message(data)
+    end
+  end
 
-  defshortcut :upload_media, "media/upload", :json, {}, {:host => "upload.twitter.com/1.1"}
+  def upload_media(io)
+    api('media/upload',
+        host: 'upload.twitter.com/1.1',
+        media: Base64.encode64(io.read)).next{|res|
+      JSON.parse(res.body)
+    }
+  end
 end
 
 module MikuTwitter::Query
@@ -19,8 +33,8 @@ module MikuTwitter::Query
 
   def method_of_api
     result = method_of_api_org
-    result['media'] = { 'upload' => :post }
-
+    result['media'] ||= {}
+    result['media']['upload'] = :post
     result
   end
 end


### PR DESCRIPTION
mikutter 3.3でも動くようにしました。3.2でも動きます。

PostBoxに変更をしたせいでなんかキャンセルボタン押さないと送信できないみたいになってたので、Serviceへのモンキーパッチをやめて、動作するようにしてみました。
また、画像投稿の部分はmikutter 3.3で入った画像投稿APIサポートを使ってやるようにしました。ただそれを使うと3.2以前で動かないので、やはりモンキーパッチで追加しています。