### PR TITLE
Replace Gdk::Pixbuf.new by GdkPixbuf::Pixbuf.new

### DIFF
--- a/penguin.rb
+++ b/penguin.rb
@@ -43,7 +43,7 @@ def choose_image_file(multi_select = false)
     filename = dialog.preview_filename
     if filename
       if FileTest.file?(filename) && FileTest.exist?(filename)
-        pixbuf = Gdk::Pixbuf.new(filename, 128, 128)
+        pixbuf = GdkPixbuf::Pixbuf.new(file: filename, width: 128, height: 128)
         preview.set_pixbuf(pixbuf)
         dialog.set_preview_widget_active(true)
       else


### PR DESCRIPTION
Deprecatedのメッセージに言われるままにGdk::Pixbuf.newを今風にした