### PR TITLE
Twitter world 選択時以外は「画像を投稿」のコマンドメニューを無効にする

### DIFF
--- a/mikutter-uwm-hommage.rb
+++ b/mikutter-uwm-hommage.rb
@@ -18,7 +18,7 @@ Plugin.create(:"mikutter-uwm-hommage") do
   # コマンド
   command(:uwm_hommage,
     name: '画像を添付',
-    condition: lambda{ |opt| true },
+    condition: ->(opt) { opt.world.class.slug == :twitter },
     icon: get_skin("image.png"),
     visible: true,
     role: :postbox


### PR DESCRIPTION
#8 で投稿ボタンだけ見えなくしましたが
postbox のコマンドメニューからも見えなくすべきですよね。

ruby も  mikutter もわかってないので書式はテキトーコピペです。